### PR TITLE
Fix: prevent overfilling by considering filled amount in match logic

### DIFF
--- a/week-2/engine/src/trade/Orderbook.ts
+++ b/week-2/engine/src/trade/Orderbook.ts
@@ -89,7 +89,7 @@ export class Orderbook {
 
         for (let i = 0; i < this.asks.length; i++) {
             if (this.asks[i].price <= order.price && executedQty < order.quantity) {
-                const filledQty = Math.min((order.quantity - executedQty), this.asks[i].quantity);
+                const filledQty = Math.min((order.quantity - executedQty), this.asks[i].quantity-this.asks[i].filled);
                 executedQty += filledQty;
                 this.asks[i].filled += filledQty;
                 fills.push({
@@ -119,7 +119,7 @@ export class Orderbook {
         
         for (let i = 0; i < this.bids.length; i++) {
             if (this.bids[i].price >= order.price && executedQty < order.quantity) {
-                const amountRemaining = Math.min(order.quantity - executedQty, this.bids[i].quantity);
+                const amountRemaining = Math.min(order.quantity - executedQty, this.bids[i].quantity-this.bids[i].filled);
                 executedQty += amountRemaining;
                 this.bids[i].filled += amountRemaining;
                 fills.push({


### PR DESCRIPTION
The calculation of filledQty (or amountRemaining) does not account for how much of the matching order has already been filled.
As a result, the same order may be used to match multiple incoming orders beyond its available quantity, leading to overfilling.